### PR TITLE
Add Terraform-based local k3d cluster with Rancher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Local Kubernetes Cluster with Rancher
+
+This project creates a local Kubernetes cluster using [k3d](https://k3d.io/) and installs Rancher via Terraform. The cluster is intended for local testing and evaluation.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/) >= 1.1
+- [k3d](https://k3d.io/) installed on your machine
+- `kubectl` available in your `$PATH`
+
+## Usage
+
+1. Clone the repository and change into the `terraform` directory:
+
+```bash
+cd terraform
+```
+
+2. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+3. Apply the configuration, setting a Rancher admin password:
+
+```bash
+terraform apply -var="rancher_admin_password=<choose-a-password>"
+```
+
+4. After the apply completes, merge the kubeconfig:
+
+```bash
+k3d kubeconfig merge rancher-test --switch
+```
+
+5. Access the Rancher UI at `https://localhost:8443` and log in with the password you provided.
+
+6. When you are done, destroy the environment:
+
+```bash
+terraform destroy
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,34 @@
+# Create a local k3d cluster using local-exec
+# This requires k3d to be installed on the machine running Terraform
+resource "null_resource" "k3d_cluster" {
+  provisioner "local-exec" {
+    command = "k3d cluster create rancher-test --agents 2"
+    interpreter = ["bash", "-c"]
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "k3d cluster delete rancher-test"
+    interpreter = ["bash", "-c"]
+  }
+}
+
+resource "helm_release" "rancher" {
+  name       = "rancher"
+  repository = "https://releases.rancher.com/server-charts/stable"
+  chart      = "rancher"
+  namespace  = "cattle-system"
+  create_namespace = true
+
+  set {
+    name  = "replicas"
+    value = 1
+  }
+
+  set {
+    name  = "bootstrapPassword"
+    value = var.rancher_admin_password
+  }
+
+  depends_on = [null_resource.k3d_cluster]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "rancher_admin_password" {
+  description = "Admin password for the Rancher UI"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.1.0"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.7.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.16.1"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}


### PR DESCRIPTION
## Summary
- create Terraform configuration for a local k3d cluster
- install Rancher via Helm
- document how to use the local cluster

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: required providers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f777996948320966e21298a14bc60