### PR TITLE
Fix Rancher install by requiring hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ terraform init
 ```
 
 3. Apply the configuration. Terraform installs cert-manager automatically
-   and then deploys Rancher. Set a Rancher admin password:
+   and then deploys Rancher. Set a Rancher admin password and optionally
+   specify a hostname for the Rancher ingress (defaults to `localhost`):
 
 ```bash
-terraform apply -var="rancher_admin_password=<choose-a-password>"
+terraform apply \
+  -var="rancher_admin_password=<choose-a-password>" \
+  -var="rancher_hostname=<your-hostname>"
 ```
 
 4. After the apply completes, merge the kubeconfig:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,11 @@ resource "helm_release" "rancher" {
   create_namespace = true
 
   set {
+    name  = "hostname"
+    value = var.rancher_hostname
+  }
+
+  set {
     name  = "replicas"
     value = 1
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,3 +14,9 @@ variable "flux_git_repository_branch" {
   type        = string
   default     = "main"
 }
+
+variable "rancher_hostname" {
+  description = "Hostname used for the Rancher ingress"
+  type        = string
+  default     = "localhost"
+}


### PR DESCRIPTION
## Summary
- allow configuring Rancher hostname
- update README to document new variable

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_684f86e90e888320a415a81961ddf152