### PR TITLE
Fix Flux bootstrap flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ terraform destroy
 
 1. Install the Flux CLI following the [official instructions](https://fluxcd.io/docs/installation/).
 1. Set the variables `flux_git_repository_url` and `flux_git_repository_branch` in `terraform.tfvars` or via the CLI. Point them at your `k8s-workloads` repository and branch.
-2. Run `terraform apply` after the Rancher installation completes. A `null_resource` will invoke `flux install` to configure Flux to watch the specified repository.
+2. Run `terraform apply` after the Rancher installation completes. A `null_resource` will invoke `flux bootstrap git` to configure Flux to watch the specified repository.
 3. Commit Kubernetes manifests to the `k8s-workloads` repository and Flux will sync them into the cluster.
 
 Flux manages workload deployment entirely from the watched Git repository.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,7 +63,7 @@ resource "null_resource" "flux_install" {
   }
 
   provisioner "local-exec" {
-    command = "flux install --namespace flux-system --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch}"
+    command = "flux bootstrap git --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch} --path=."
   }
 }
 


### PR DESCRIPTION
## Summary
- use `flux bootstrap git` instead of the deprecated `flux install --url`
- update README instructions

## Testing
- `terraform fmt -check`
- `terraform validate` *(fails: missing providers because `terraform init` cannot access registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_684f8a2b709483208807ac7eac949911