### PR TITLE
Fix Flux bootstrap token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ terraform destroy
 1. Set the variables `flux_git_repository_url` and `flux_git_repository_branch` in `terraform.tfvars` or via the CLI. Point them at your `k8s-workloads` repository and branch.
    Provide a GitHub token via the `flux_github_token` variable so Flux can push manifests during bootstrapping.
 2. Run `terraform apply` after the Rancher installation completes. A `null_resource` will invoke `flux bootstrap git` to configure Flux to watch the specified repository.
-   The bootstrap command is executed with `TMPDIR=/tmp/fluxcd`, and the GitHub token is exported as `GITHUB_TOKEN` so Flux clones repositories in `/tmp/fluxcd` and pushes manifests with your credentials.
+   The bootstrap command runs with `TMPDIR=/tmp/fluxcd`. The token is exported as `GIT_PASSWORD` and Flux is invoked with `--token-auth --username=git` so it can clone your repository and push manifests without prompting.
 3. Commit Kubernetes manifests to the `k8s-workloads` repository and Flux will sync them into the cluster.
 
 Flux manages workload deployment entirely from the watched Git repository.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,10 +63,10 @@ resource "null_resource" "flux_install" {
   }
 
   provisioner "local-exec" {
-    command = "mkdir -p /tmp/fluxcd && flux bootstrap git --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch} --path=. --token-auth"
+    command = "mkdir -p /tmp/fluxcd && flux bootstrap git --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch} --path=. --token-auth --username=git"
     environment = {
       TMPDIR       = "/tmp/fluxcd"
-      GITHUB_TOKEN = var.flux_github_token
+      GIT_PASSWORD = var.flux_github_token
     }
   }
 }


### PR DESCRIPTION
## Summary
- document using `GIT_PASSWORD` for Flux bootstrap
- pass the token as `GIT_PASSWORD` via Terraform and set `--username=git`

## Testing
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_684f92efccfc83208d8ec59935a8a583