### PR TITLE
Refactor Terraform code into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project creates a local Kubernetes cluster using [k3d](https://k3d.io/) and installs Rancher via Terraform. The cluster is intended for local testing and evaluation.
 
+The Terraform configuration is structured using reusable modules located under `terraform/modules` to keep the codebase organized.
+
 ## Prerequisites
 
 - [Terraform](https://www.terraform.io/) >= 1.1
@@ -25,12 +27,16 @@ terraform init
 
 3. Apply the configuration. Terraform installs cert-manager automatically
    and then deploys Rancher. Set a Rancher admin password and optionally
-   specify a hostname for the Rancher ingress (defaults to `localhost`):
+   specify a hostname for the Rancher ingress (defaults to `localhost`).
+   The `cluster_name` and `agent_count` variables can be used to
+   customize the k3d cluster name and number of agent nodes:
 
 ```bash
 terraform apply \
   -var="rancher_admin_password=<choose-a-password>" \
-  -var="rancher_hostname=<your-hostname>"
+  -var="rancher_hostname=<your-hostname>" \
+  -var="cluster_name=<cluster-name>" \
+  -var="agent_count=<number-of-agents>"
 ```
 
 4. After the apply completes, Terraform starts a port-forward from the

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,89 +1,30 @@
-# Create a local k3d cluster using local-exec
-# This requires k3d to be installed on the machine running Terraform
-resource "null_resource" "k3d_cluster" {
-  provisioner "local-exec" {
-    command     = "k3d cluster create rancher-test --agents 2"
-    interpreter = ["bash", "-c"]
-  }
-
-  provisioner "local-exec" {
-    when        = destroy
-    command     = "k3d cluster delete rancher-test"
-    interpreter = ["bash", "-c"]
-  }
+module "k3d_cluster" {
+  source       = "./modules/k3d_cluster"
+  cluster_name = var.cluster_name
+  agent_count  = var.agent_count
 }
 
-resource "helm_release" "cert_manager" {
-  name             = "cert-manager"
-  repository       = "https://charts.jetstack.io"
-  chart            = "cert-manager"
-  namespace        = "cert-manager"
-  create_namespace = true
-
-  set {
-    name  = "installCRDs"
-    value = true
-  }
-
-  depends_on = [null_resource.k3d_cluster]
+module "cert_manager" {
+  source     = "./modules/cert_manager"
+  depends_on = [module.k3d_cluster]
 }
 
-resource "helm_release" "rancher" {
-  name             = "rancher"
-  repository       = "https://releases.rancher.com/server-charts/stable"
-  chart            = "rancher"
-  namespace        = "cattle-system"
-  create_namespace = true
-
-  set {
-    name  = "hostname"
-    value = var.rancher_hostname
-  }
-
-  set {
-    name  = "replicas"
-    value = 1
-  }
-
-  set_sensitive {
-    name  = "bootstrapPassword"
-    value = var.rancher_admin_password
-    type  = "string"
-  }
-
-  depends_on = [helm_release.cert_manager]
+module "rancher" {
+  source                 = "./modules/rancher"
+  rancher_hostname       = var.rancher_hostname
+  rancher_admin_password = var.rancher_admin_password
+  depends_on             = [module.cert_manager]
 }
 
-# Port-forward the Rancher service locally
-resource "null_resource" "rancher_port_forward" {
-  depends_on = [helm_release.rancher]
-
-  provisioner "local-exec" {
-    command     = "nohup kubectl -n cattle-system port-forward svc/rancher 8443:443 >/tmp/rancher-port-forward.log 2>&1 & echo $! > /tmp/rancher-port-forward.pid"
-    interpreter = ["bash", "-c"]
-  }
-
-  provisioner "local-exec" {
-    when        = destroy
-    command     = "if [ -f /tmp/rancher-port-forward.pid ]; then kill $(cat /tmp/rancher-port-forward.pid); rm /tmp/rancher-port-forward.pid; fi"
-    interpreter = ["bash", "-c"]
-  }
+module "rancher_port_forward" {
+  source     = "./modules/rancher_port_forward"
+  depends_on = [module.rancher]
 }
 
-# Install FluxCD once Rancher is ready
-resource "null_resource" "flux_install" {
-  depends_on = [helm_release.rancher]
-
-  triggers = {
-    always_run = timestamp()
-  }
-
-  provisioner "local-exec" {
-    command = "mkdir -p /tmp/fluxcd && flux bootstrap git --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch} --path=. --token-auth --username=git"
-    environment = {
-      TMPDIR       = "/tmp/fluxcd"
-      GIT_PASSWORD = var.flux_github_token
-    }
-  }
+module "flux" {
+  source                     = "./modules/flux"
+  flux_git_repository_url    = var.flux_git_repository_url
+  flux_git_repository_branch = var.flux_git_repository_branch
+  flux_github_token          = var.flux_github_token
+  depends_on                 = [module.rancher]
 }
-

--- a/terraform/modules/cert_manager/main.tf
+++ b/terraform/modules/cert_manager/main.tf
@@ -1,0 +1,12 @@
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = true
+  }
+}

--- a/terraform/modules/flux/main.tf
+++ b/terraform/modules/flux/main.tf
@@ -1,0 +1,13 @@
+resource "null_resource" "flux_install" {
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p /tmp/fluxcd && flux bootstrap git --url=${var.flux_git_repository_url} --branch=${var.flux_git_repository_branch} --path=. --token-auth --username=git"
+    environment = {
+      TMPDIR       = "/tmp/fluxcd"
+      GIT_PASSWORD = var.flux_github_token
+    }
+  }
+}

--- a/terraform/modules/flux/variables.tf
+++ b/terraform/modules/flux/variables.tf
@@ -1,0 +1,12 @@
+variable "flux_git_repository_url" {
+  type = string
+}
+
+variable "flux_git_repository_branch" {
+  type = string
+}
+
+variable "flux_github_token" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/modules/k3d_cluster/main.tf
+++ b/terraform/modules/k3d_cluster/main.tf
@@ -1,0 +1,17 @@
+resource "null_resource" "cluster" {
+  triggers = {
+    cluster_name = var.cluster_name
+    agent_count  = var.agent_count
+  }
+
+  provisioner "local-exec" {
+    command     = "k3d cluster create ${self.triggers.cluster_name} --agents ${self.triggers.agent_count}"
+    interpreter = ["bash", "-c"]
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    command     = "k3d cluster delete ${self.triggers.cluster_name}"
+    interpreter = ["bash", "-c"]
+  }
+}

--- a/terraform/modules/k3d_cluster/variables.tf
+++ b/terraform/modules/k3d_cluster/variables.tf
@@ -1,0 +1,7 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "agent_count" {
+  type = number
+}

--- a/terraform/modules/rancher/main.tf
+++ b/terraform/modules/rancher/main.tf
@@ -1,0 +1,23 @@
+resource "helm_release" "rancher" {
+  name             = "rancher"
+  repository       = "https://releases.rancher.com/server-charts/stable"
+  chart            = "rancher"
+  namespace        = "cattle-system"
+  create_namespace = true
+
+  set {
+    name  = "hostname"
+    value = var.rancher_hostname
+  }
+
+  set {
+    name  = "replicas"
+    value = 1
+  }
+
+  set_sensitive {
+    name  = "bootstrapPassword"
+    value = var.rancher_admin_password
+    type  = "string"
+  }
+}

--- a/terraform/modules/rancher/variables.tf
+++ b/terraform/modules/rancher/variables.tf
@@ -1,0 +1,7 @@
+variable "rancher_hostname" {
+  type = string
+}
+
+variable "rancher_admin_password" {
+  type = string
+}

--- a/terraform/modules/rancher_port_forward/main.tf
+++ b/terraform/modules/rancher_port_forward/main.tf
@@ -1,0 +1,12 @@
+resource "null_resource" "port_forward" {
+  provisioner "local-exec" {
+    command     = "nohup kubectl -n cattle-system port-forward svc/rancher 8443:443 >/tmp/rancher-port-forward.log 2>&1 & echo $! > /tmp/rancher-port-forward.pid"
+    interpreter = ["bash", "-c"]
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    command     = "if [ -f /tmp/rancher-port-forward.pid ]; then kill $(cat /tmp/rancher-port-forward.pid); rm /tmp/rancher-port-forward.pid; fi"
+    interpreter = ["bash", "-c"]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,3 +27,15 @@ variable "rancher_hostname" {
   type        = string
   default     = "localhost"
 }
+
+variable "cluster_name" {
+  description = "Name of the k3d cluster"
+  type        = string
+  default     = "rancher-test"
+}
+
+variable "agent_count" {
+  description = "Number of k3d agent nodes"
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Summary
- introduce modular structure under `terraform/modules`
- update variables to support cluster customization
- document new structure and example vars in README

## Testing
- `terraform fmt -recursive -check`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684f9e0722b0832087fd7afb0381726f