### PR TITLE
Add storage_path variable for cluster data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ terraform init
    and then deploys Rancher. Set a Rancher admin password and optionally
    specify a hostname for the Rancher ingress (defaults to `rancher.local`).
    The `cluster_name` and `agent_count` variables can be used to
-   customize the k3d cluster name and number of agent nodes:
+   customize the k3d cluster name and number of agent nodes. The
+   `storage_path` variable specifies a host directory used to persist
+   cluster data (defaults to `/media/acid/windows`):
 
 ```bash
 terraform apply \
   -var="rancher_admin_password=<choose-a-password>" \
   -var="rancher_hostname=<your-hostname>" \
   -var="cluster_name=<cluster-name>" \
-  -var="agent_count=<number-of-agents>"
+  -var="agent_count=<number-of-agents>" \
+  -var="storage_path=<host-storage-directory>"
 ```
 
 4. After the apply completes, merge the kubeconfig so `kubectl` can reach

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,6 +2,7 @@ module "k3d_cluster" {
   source       = "./modules/k3d_cluster"
   cluster_name = var.cluster_name
   agent_count  = var.agent_count
+  storage_path = var.storage_path
 }
 
 module "cert_manager" {

--- a/terraform/modules/k3d_cluster/main.tf
+++ b/terraform/modules/k3d_cluster/main.tf
@@ -2,10 +2,11 @@ resource "null_resource" "cluster" {
   triggers = {
     cluster_name = var.cluster_name
     agent_count  = var.agent_count
+    storage_path = var.storage_path
   }
 
   provisioner "local-exec" {
-    command     = "k3d cluster create ${self.triggers.cluster_name} --agents ${self.triggers.agent_count} -p \"80:80@loadbalancer\" -p \"443:443@loadbalancer\""
+    command     = "k3d cluster create ${self.triggers.cluster_name} --agents ${self.triggers.agent_count} -p \"80:80@loadbalancer\" -p \"443:443@loadbalancer\" --volume ${self.triggers.storage_path}:/var/lib/rancher/k3s@server:0"
     interpreter = ["bash", "-c"]
   }
 

--- a/terraform/modules/k3d_cluster/variables.tf
+++ b/terraform/modules/k3d_cluster/variables.tf
@@ -5,3 +5,8 @@ variable "cluster_name" {
 variable "agent_count" {
   type = number
 }
+
+variable "storage_path" {
+  type        = string
+  description = "Host path used to persist k3s data"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,3 +39,9 @@ variable "agent_count" {
   type        = number
   default     = 2
 }
+
+variable "storage_path" {
+  description = "Host path used to persist k3s data"
+  type        = string
+  default     = "/media/acid/windows"
+}


### PR DESCRIPTION
## Summary
- allow specifying a host storage path for k3d data
- mount the storage path when creating the cluster
- document new `storage_path` variable in the README

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_684fbd688b748320a74f28fce454e102