### PR TITLE
Switch to pvotal-tech k3d provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Local Kubernetes Cluster with Rancher
 
-This project creates a local Kubernetes cluster using [k3d](https://k3d.io/) and installs Rancher via Terraform. The cluster is managed through the [official k3d provider](https://registry.terraform.io/providers/nikhilsbhat/k3d/latest/docs) and is intended for local testing and evaluation.
+This project creates a local Kubernetes cluster using [k3d](https://k3d.io/) and installs Rancher via Terraform. The cluster is managed through the [pvotal-tech k3d provider](https://registry.terraform.io/providers/pvotal-tech/k3d/latest) and is intended for local testing and evaluation.
 
 The Terraform configuration is structured using reusable modules located under `terraform/modules` to keep the codebase organized.
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -60,21 +60,20 @@ provider "registry.terraform.io/hashicorp/null" {
   ]
 }
 
-provider "registry.terraform.io/nikhilsbhat/k3d" {
-  version     = "0.0.2"
-  constraints = ">= 0.0.2"
+provider "registry.terraform.io/pvotal-tech/k3d" {
+  version     = "0.0.7"
+  constraints = ">= 0.0.7"
   hashes = [
-    "h1:RYasFYICoDdlOtRZhKoBnkOoKp9IN4Iz7yVaRQudL9s=",
-    "zh:03a4983cdd8adac32f1ad2d94ec57260d04bd5d66e4a996029d10eea3a80c06c",
-    "zh:0cb151fb458d7160593f18a9be324820b8b9eac95b1b4ace5941c504c62e96ee",
-    "zh:19bcf3660ac7545103cf999e0066442f9d6350db9654e1496726520cef287246",
-    "zh:42785b59f330e290db08fbeaaaab6da4f9056130e884b3c364bb200e0d6bc578",
-    "zh:476f689bead27dd882de86bb1953122e00aa6ecf78693bbac2dfe07750172a69",
-    "zh:49262213579c8d0c6ac29ba222b1fd2341d68727a02c722e0671a5cf8d880492",
-    "zh:4d931c3833295c4a9e2c67b9bd2b13dc616c6e88c923aa660a7d9aca10a9c3b2",
-    "zh:722323a89d1db9c7ca12028243e0dd163684d42a2a0c8efc6cb21e0cafb4616c",
-    "zh:803b5211b196d1c3f3fb40d8b21f5ca394abf8bc1b46a4e0d6c8a7b6221cbbca",
-    "zh:c4756adf57e53111d10c8a8772bc5ea5110de18e7fd48c3de9a3e12504a746ad",
-    "zh:e8014e17f27eb1723083f5a1023b445bace2da5b86b3dc3a786ba2e17d6a03ef",
+    "h1:5hFF1FqNShTc4Gfv5xmXuzcfMxlsOygEez1oiPqXDa0=",
+    "zh:1ada0ac98777b2348ad068dda53238934805a8222f28afb887752c836ffbf98d",
+    "zh:27088117e25872e99a3f03b31165d38a207f6e8c5a4443070e282e6b0a06bd8a",
+    "zh:3b29dae81e1e9ff6d77eb4ab309aa2d6bde654bec3eaf5978796386e319aed01",
+    "zh:6a3b1b15442bc9fb2f447fea2c5dbcee43d0cc84fb21ceebca62df708ad2e672",
+    "zh:7bd58cbf0244dcdc7f322472c78b2eda6597a11568d3dc78cbd1b80031560b89",
+    "zh:7fc85cf5a10acec629ef72aa779e6c0d0ad84eafb8d8312233a99d36715fe65d",
+    "zh:871caee0e89c0dffc4248262305efde8f9d4ec38fad7e83a83ef0a210888293c",
+    "zh:941e862447721d01fb97921bcfcaec09a560fb8a680b889655191e61f12a9bca",
+    "zh:bddaebe40d1e0f0cbbe9a2a044d7be2766a54efc87b641aae2e8848862b81ef1",
+    "zh:e30130828bd3b6d7303395de483e135d1d3fe91543af6c237c0cac7c19978e51",
   ]
 }

--- a/terraform/modules/k3d_cluster/main.tf
+++ b/terraform/modules/k3d_cluster/main.tf
@@ -1,28 +1,28 @@
 resource "k3d_cluster" "cluster" {
-  name          = var.cluster_name
-  servers_count = 1
-  agents_count  = var.agent_count
+  name    = var.cluster_name
+  servers = 1
+  agents  = var.agent_count
 
-  ports {
+  port {
     host_port      = 80
     container_port = 80
     node_filters   = ["loadbalancer"]
   }
 
-  ports {
+  port {
     host_port      = 443
     container_port = 443
     node_filters   = ["loadbalancer"]
   }
 
-  volumes {
+  volume {
     source       = var.storage_path
     destination  = "/var/lib/rancher/k3s"
     node_filters = ["server:0"]
   }
 
-  kube_config {
-    update_default = true
-    switch_context = true
+  kubeconfig {
+    update_default_kubeconfig = true
+    switch_current_context    = true
   }
 }

--- a/terraform/modules/k3d_cluster/variables.tf
+++ b/terraform/modules/k3d_cluster/variables.tf
@@ -1,10 +1,10 @@
 variable "cluster_name" {
-  type = string
+  type    = string
   default = "local-k3s-cluster"
 }
 
 variable "agent_count" {
-  type = number
+  type    = number
   default = 2
 }
 

--- a/terraform/modules/k3d_cluster/versions.tf
+++ b/terraform/modules/k3d_cluster/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     k3d = {
-      source  = "nikhilsbhat/k3d"
-      version = ">= 0.0.2"
+      source  = "pvotal-tech/k3d"
+      version = ">= 0.0.7"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -10,8 +10,8 @@ terraform {
       version = ">= 2.16.1"
     }
     k3d = {
-      source  = "nikhilsbhat/k3d"
-      version = ">= 0.0.2"
+      source  = "pvotal-tech/k3d"
+      version = ">= 0.0.7"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use the pvotal-tech/k3d Terraform provider
- update k3d cluster resource fields for new provider
- run `terraform init -upgrade` to refresh `.terraform.lock.hcl`

## Testing
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6850e3d9e82c8320ac15bac0617af24f